### PR TITLE
fix some dependencies warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "js-cookie": "3.0.1",
         "tweetnacl": "1.0.3",
         "tweetnacl-util": "0.15.1",
-        "typescript-is": "0.18.2",
         "util": "0.12.4"
     },
     "devDependencies": {
@@ -61,6 +60,7 @@
         "ts-node": "10.4.0",
         "ttypescript": "1.5.12",
         "typescript": "4.2.4",
+        "typescript-is": "0.18.2",
         "webpack": "5.37.1",
         "webpack-cli": "4.7.0",
         "webpack-dev-server": "4.0.0-beta.3"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@types/crypto-js": "4.0.2",
         "@types/jest": "27.0.3",
         "@types/js-cookie": "2.2.7",
+        "@types/node": "17.0.21",
         "axios-mock-adapter": "1.20.0",
         "babel-loader": "8.2.2",
         "husky": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,6 +2007,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.2.tgz#51e9c0920d1b45936ea04341aa3e2e58d339fb67"
   integrity sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==
 
+"@types/node@17.0.21":
+  version "17.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
+  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
the `typescript-is` library should not be placed in **dependencies**, 
```
~/workspaces/rss3-test > pnpm init -y                                                                                                              05:42:34 下午
Wrote to /Users/dmoo/workspaces/rss3-test/package.json:

{
  "name": "rss3-test",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC"
}


~/workspaces/rss3-test > pnpm add rss3 -S                                                                                                          05:42:39 下午
Packages: +99
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /Users/dmoo/.pnpm-store/v3
  Virtual store is at:             node_modules/.pnpm
Progress: resolved 99, reused 99, downloaded 0, added 99, done

dependencies:
+ rss3 0.8.19

 WARN  Issues with peer dependencies found
.
└─┬ rss3
  └─┬ typescript-is
    ├── ✕ missing peer typescript@^4.1.5
    └─┬ tsutils
      └── ✕ missing peer typescript@">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
Peer dependencies that should be installed:
  typescript@">=4.1.5 <5.0.0"
```

the `ts-node` is peer dependency `@types/node@*`

```
warning " > ts-node@10.4.0" has unmet peer dependency "@types/node@*".
```